### PR TITLE
Adapt for Firefox Linter

### DIFF
--- a/chrome-extension/bg/background.js
+++ b/chrome-extension/bg/background.js
@@ -1,7 +1,8 @@
 import init, { ImageResult } from './paa.js';
 
 async function run() {
-    let app = await init();
+    // Firefox linter has trouble with 'import', so import directly here
+    let app = await init(`${window.location.origin}/bg/paa_bg.wasm`);
 
     chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
         if (request.contentScriptQuery == "fetch_blob") {

--- a/chrome-extension/bg/paa.js
+++ b/chrome-extension/bg/paa.js
@@ -119,9 +119,6 @@ async function load(module, imports) {
 }
 
 async function init(input) {
-    if (typeof input === 'undefined') {
-        input = import.meta.url.replace(/\.js$/, '_bg.wasm');
-    }
     const imports = {};
     imports.wbg = {};
     imports.wbg.__wbindgen_object_drop_ref = function(arg0) {


### PR DESCRIPTION
Firefox submission linter is a bit stupid and can't process `import`, this is a hack around it by @veteran29.

This will allow publishing the extension for Firefox.