### PR TITLE
Add support for diff pages

### DIFF
--- a/chrome-extension/sites/github.js
+++ b/chrome-extension/sites/github.js
@@ -1,16 +1,46 @@
 function pathChanged() {
-    if (!window.location.pathname.endsWith(".paa")) return;
+    // File view page
+    if (window.location.pathname.endsWith(".paa")) {
+        let interval = setInterval(function() {
+            try {
+                let wrapper = document.getElementsByClassName("blob-wrapper")[0].firstChild.nextSibling.firstChild.nextSibling;
+                wrapper.textContent = "Converting PAA...";
+                clearInterval(interval);
+                let image = document.createElement("img");
+                chrome.runtime.sendMessage({contentScriptQuery: "fetch_blob", src: "https://github.com" + window.location.pathname + "?raw=true"}, response => {
+                    image.src = response;
+                    wrapper.replaceWith(image);
+                });
+            } catch {}
+        }, 10);
+    }
+
+    // Diff page
+    let diffs = document.querySelectorAll("div[data-file-type='.paa'][class~='file']");
     let interval = setInterval(function() {
-        try {
-            let wrapper = document.getElementsByClassName("blob-wrapper")[0].firstChild.nextSibling.firstChild.nextSibling;
-            wrapper.textContent = "Converting PAA...";
-            clearInterval(interval);
-            let image = document.createElement("img");
-            chrome.runtime.sendMessage({contentScriptQuery: "fetch_blob", src: "https://github.com" + window.location.pathname + "?raw=true"}, response => {
-                image.src = response;
-                wrapper.replaceWith(image);
-            });
-        } catch {}
+        for (diff of diffs) {
+            try {
+                let wrapper = diff.firstElementChild.nextElementSibling.firstElementChild;
+                wrapper.textContent = "Converting PAA...";
+                clearInterval(interval);
+
+                // Put into image sizing div like on file view page to center
+                let divimage = document.createElement("div");
+                divimage.setAttribute("itemprop", "text");
+                divimage.setAttribute("class", "Box-body p-0 blob-wrapper data type-text gist-border-0");
+                let divcenter = document.createElement("div");
+                divcenter.setAttribute("class", "text-center p-3");
+                divimage.appendChild(divcenter);
+                let image = document.createElement("img");
+                divcenter.appendChild(image);
+
+                let rawlink = diff.querySelectorAll("a")[1].href; // "View file" button link
+                chrome.runtime.sendMessage({contentScriptQuery: "fetch_blob", src: rawlink + "?raw=true"}, response => {
+                    image.src = response;
+                    wrapper.replaceWith(divimage);
+                });
+            } catch {}
+        }
     }, 10);
 }
 


### PR DESCRIPTION
Tested on Firefox and Chrome, displays new PAA image on PR diff and commit diff. Also wraps the image in an image div display with scrollbars like direct file views (does not get done by GitHub due to below).

No binary files are actually displayed on diff pages, so I don't know if this really fits the scope of the extension. Maybe we should add an extension setting to control this?

Off-topic for this PR, but I noticed GitHub won't display very large images (PNG etc.) by default (eg. texture sizes), maybe we should add a similar limit to decrease bandwidth.

![image](https://user-images.githubusercontent.com/7935003/90338473-3ef7f400-dfea-11ea-93c7-ce0cc7bcefaf.png)