### PR TITLE
Add Firefox addon ID to manifest V3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 pkg/
 *.pem
 *.crx
+web-ext-artifacts/

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -26,5 +26,10 @@
     },
     "host_permissions": [
         "https://github.com/*"
-    ]
+    ],
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "{10d6a2c8-ce08-41e6-95a0-4336400419bd}"
+        }
+    }
 }


### PR DESCRIPTION
Required for Firefox.

Additionally, Firefox v109 has been released on January 17th and is the first version to support manifest V3. As the user-base of PAA Viewer on Firefox is not large, I think that is fine and we don't have to worry about manifest V2 support.