### PR TITLE
Rewrite web extension

### DIFF
--- a/extension/sites/github.js
+++ b/extension/sites/github.js
@@ -1,68 +1,128 @@
-function pathChanged() {
-    // File view page
-    if (window.location.pathname.endsWith(".paa")) {
-        let interval = setInterval(function () {
-            try {
-                let wrapper = document.getElementsByClassName("blob-wrapper")[0].firstChild.nextSibling.firstChild.nextSibling;
-                wrapper.textContent = "Converting PAA...";
-                clearInterval(interval);
-                let image = document.createElement("img");
-                fetch(window.location.href + "?raw=true")
-                    .then(response => response.blob())
-                    .then(blob => blob.arrayBuffer()).then(ab => {
-                        chrome.runtime.sendMessage({contentScriptQuery: "fetch_blob", ab: Array.from(new Uint8Array(ab))}, response => {
-                            image.src = response;
-                            wrapper.replaceWith(image);
-                        });
-                });
-            } catch { }
-        }, 50);
+// Load PAAs only when visible
+const intersectionObserver = new IntersectionObserver(entries => {
+    for (const entry of entries.filter(entry => entry.isIntersecting)) {
+        replacePaa({ block: entry.target, ...JSON.parse(entry.target.dataset.paaRs) });
+    }
+});
+
+const onRender = () => {
+    // Load / lazy-load PAAs
+    for (const paa of findPaas()) {
+        const dataset = paa.block.dataset;
+        if (dataset.paaRs && JSON.parse(dataset.paaRs).href !== paa.href) {
+            dataset.paaRs = JSON.stringify({ href: paa.href, class: paa.class });
+            replacePaa(paa);
+        } else {
+            dataset.paaRs = JSON.stringify({ href: paa.href, class: paa.class });
+            intersectionObserver.observe(paa.block);
+        }
     }
 
-    // Diff page
-    if (window.location.pathname.endsWith("/files")) {
-        let tries = 150;
-        let interval = setInterval(function () {
-            if (tries-- < 0) {
-                clearInterval(interval);
-                return;
-            }
-            let diffs = document.querySelectorAll("div[data-file-type='.paa'][class~='file']");
-            for (diff of diffs) {
-                try {
-                    let wrapper = diff.firstElementChild.nextElementSibling.firstElementChild;
-                    wrapper.textContent = "Converting PAA...";
-                    clearInterval(interval);
-
-                    // Put into image sizing div like on file view page to center
-                    let divimage = document.createElement("div");
-                    divimage.setAttribute("itemprop", "text");
-                    divimage.setAttribute("class", "Box-body p-0 blob-wrapper data type-text gist-border-0");
-                    let divcenter = document.createElement("div");
-                    divcenter.setAttribute("class", "text-center p-3");
-                    divimage.appendChild(divcenter);
-                    let image = document.createElement("img");
-                    divcenter.appendChild(image);
-
-                    fetch(diff.querySelectorAll("a")[1].href + "?raw=true")
-                        .then(response => response.blob())
-                        .then(blob => blob.arrayBuffer()).then(ab => {
-                            chrome.runtime.sendMessage({contentScriptQuery: "fetch_blob", ab: Array.apply(null,new Uint8Array(ab))}, response => {
-                                image.src = response;
-                                wrapper.replaceWith(divimage);
-                            });
-                        });
-                } catch { }
-            }
-        }, 100);
+    // Remove orphaned PAAs
+    for (const paaRsEl of document.querySelectorAll(".paa-rs-spinner, .paa-rs-single, .paa-rs-list")) {
+        if (!paaRsEl.previousElementSibling || !paaRsEl.previousElementSibling.dataset.paaRs) {
+            paaRsEl.remove();
+        }
     }
-}
+};
 
-pathChanged();
-let path = window.location.pathname;
-setInterval(function () {
-    if (path != window.location.pathname) {
-        pathChanged();
-        path = window.location.pathname;
+const findPaas = () => {
+    const viewRawBlocks = Array.from(document.querySelectorAll("div a[href$='.paa'], div a[href$='.paa?raw=true']"))
+        .filter(a => a.innerText === "View raw")
+        .map(a => ({
+            block: a.parentElement,
+            href: a.href,
+            class: "single",
+        }));
+
+    const binaryFileNotShownBlocks = Array.from(document.querySelectorAll("div[data-file-type='.paa'] + div .empty"))
+        .map(div => ({
+            block: div,
+            href: div.parentElement.parentElement.querySelector("a[href$='.paa']").href,
+            class: "list",
+        }));
+
+    return viewRawBlocks.concat(binaryFileNotShownBlocks);
+};
+
+const replacePaa = (paa) => {
+    // Block cannot be completely removed because of React
+    paa.block.style.display = "none";
+
+    // Remove spinner or previously loaded PAA
+    if (paa.block.nextElementSibling && paa.block.nextElementSibling.className.startsWith("paa-rs")) {
+        paa.block.nextElementSibling.remove();
     }
-}, 10);
+
+    // Add spinner
+    const spinner = document.createElement("i");
+    spinner.classList.add("paa-rs-spinner");
+    paa.block.insertAdjacentElement("afterend", spinner);
+
+    fetch(paa.href + "?raw=true")
+        .then(response => response.blob())
+        .then(blob => blob.arrayBuffer()).then(ab => {
+            chrome.runtime.sendMessage({contentScriptQuery: "fetch_blob", ab: Array.from(new Uint8Array(ab))}, response => {
+                // Abort if spinner was removed - user might have clicked and loaded a different PAA already
+                if (!document.body.contains(spinner)) {
+                    return;
+                }
+                
+                const img = document.createElement("img");
+                img.classList.add(`paa-rs-${paa.class}`);
+                img.src = response;
+                spinner.replaceWith(img);
+            });
+        });
+};
+
+const addStyles = () => {
+    const style = document.createElement("style");
+    style.appendChild(document.createTextNode(`
+        /* Spinner based on https://cssloaders.github.io/ */
+        i.paa-rs-spinner {
+            display: block;
+            width: 58px;
+            height: 58px;
+            margin: 30px auto;
+            border: 2px solid var(--color-fg-subtle);
+            border-bottom-color: var(--color-fade-fg-30);
+            border-radius: 50%;
+            box-sizing: border-box;
+            animation: paa-rs-rotation 1s linear infinite;
+        }
+        @keyframes paa-rs-rotation {
+            0% { transform: rotate(0deg) }
+            100% { transform: rotate(360deg) }
+        }
+        img.paa-rs-single {
+            display: block;
+            max-width: 100%;
+            margin: 0 auto;
+        }
+        img.paa-rs-list {
+            display: block;
+            max-width: 600px;
+            margin: 30px auto;
+            background: url("https://viewscreen.githubusercontent.com/static/bg.gif") right bottom #f6f8fa;
+            border: 2px solid hsla(210,18%,87%,1);
+        }
+    `));
+
+    document.head.appendChild(style);
+};
+
+const init = () => {
+    addStyles();
+    onRender();
+    
+    const mutationObserver = new MutationObserver(_ => onRender());
+    mutationObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["href"],
+    });
+};
+
+init();


### PR DESCRIPTION
This is a rewrite of the web extension for GitHub. It adds the following features:
- Using a mutation observer instead of polling to check for changes (should increase performance)
- Support for the new and the old repository browser
- Support for dark and light themes
- Aligned styling with GitHub's image rendering
  - limit image width to a sensible maximum
  - a checkerboard pattern background to show transparency
- A loading spinner
- Lazy conversion of PAAs

I have tested this successfully in Firefox, but Chrome nags about Manifest V3. I haven't looked into that at all.

![grafik](https://github.com/BrettMayson/paa/assets/9693842/4be2197e-85f6-49f1-bade-d88c9082c1e8)

![grafik](https://github.com/BrettMayson/paa/assets/9693842/931e4f71-f0ee-4657-a6ae-0f82f67da517)
